### PR TITLE
improves JS load-order handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ var gmail;
 
 
 function refresh(f) {
-  if(/in/.test(document.readyState)) {
+  if( (/in/.test(document.readyState)) || (undefined === Gmail) ) {
     setTimeout('refresh(' + f + ')', 10);
   } else {
     f();


### PR DESCRIPTION
I was getting an intermittent load-order error (Gmail is undefined) apparently due to `main()` running before `gmail.js` loaded. I didn't get far into understanding why that was happening, but asking the existing document state check to also check for the Gmail object seemed to clear it up. 