### PR TITLE
don't break other google products

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "Hello World Gmail chrome extension",
   "content_scripts": [
     {
-      "matches": ["https://*.google.com/*"],
+      "matches": ["https://mail.google.com/*"],
       "js": ["content.js"]
     }
   ],


### PR DESCRIPTION
* make it work just for gmail, and not for all google products e.g. docs
* it potentially breaks others cause of missing GLOBALS on others